### PR TITLE
feat: use page title as manual title

### DIFF
--- a/Resources/Private/Templates/Default.html
+++ b/Resources/Private/Templates/Default.html
@@ -5,7 +5,7 @@
         <f:if condition="{backendSettings.backendLogo}">
             <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
         </f:if>
-        <h1>TYPO3-Handbuch</h1>
+        <h1>{data.title}</h1>
     </section>
 
     <f:if condition="{context} != 'pdf'">


### PR DESCRIPTION
Use the page title of the root page to adjust the manual title (and possible support multiple manuals within one TYPO3 instance). 