### PR TITLE
fix: template logo condition

### DIFF
--- a/Resources/Private/Templates/Default.html
+++ b/Resources/Private/Templates/Default.html
@@ -2,7 +2,7 @@
 
 <main style="--link-color:{backendSettings.loginHighlightColor}">
     <section class="section cover">
-        <f:if condition="{backendSettings.backendLogo}">
+        <f:if condition="{backendSettings.loginLogo}">
             <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
         </f:if>
         <h1>{title}</h1>


### PR DESCRIPTION
The condition for rendering the backend logo in the template manual uses the wrong identifier