### PR TITLE
feat: add access restriction for backend user groups

### DIFF
--- a/Classes/DataProcessing/MenuAccessProcessor.php
+++ b/Classes/DataProcessing/MenuAccessProcessor.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Xima\XimaTypo3Manual\DataProcessing;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+use Xima\XimaTypo3Manual\Security\BackendUserGroupAccessCheck;
+
+class MenuAccessProcessor implements DataProcessorInterface
+{
+    /**
+     * @param mixed[] $contentObjectConfiguration
+     * @param mixed[] $processorConfiguration
+     * @param mixed[] $processedData
+     * @return mixed[]
+     */
+    public function process(
+        ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData
+    ): array {
+        $accessCheck = GeneralUtility::makeInstance(BackendUserGroupAccessCheck::class);
+        $context = GeneralUtility::makeInstance(Context::class);
+
+        foreach ($processedData['pages'] as $key => $page) {
+            if ($accessCheck->groupAccessGranted($page['data'], $context)) {
+                continue;
+            }
+            unset($processedData['pages'][$key]);
+        }
+        return $processedData;
+    }
+}

--- a/Classes/EventListener/BackendUserGroupAccessEventListener.php
+++ b/Classes/EventListener/BackendUserGroupAccessEventListener.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xima\XimaTypo3Manual\EventListener;
+
+use TYPO3\CMS\Core\Domain\Access\RecordAccessGrantedEvent;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use Xima\XimaTypo3Manual\Security\BackendUserGroupAccessCheck;
+
+final class BackendUserGroupAccessEventListener
+{
+    public function __construct(protected PageRepository $pageRepository, protected BackendUserGroupAccessCheck $check) {}
+    public function __invoke(RecordAccessGrantedEvent $event): void
+    {
+        // ToDo: Why only get a part of the full page record?
+        $fullPageRecord = $this->pageRepository->getPage($event->getRecord()['uid']);
+        $event->setAccessGranted($this->check->groupAccessGranted($fullPageRecord, $event->getContext()));
+    }
+}
+

--- a/Classes/Security/BackendUserGroupAccessCheck.php
+++ b/Classes/Security/BackendUserGroupAccessCheck.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xima\XimaTypo3Manual\Security;
+
+use TYPO3\CMS\Core\Context\Context;
+
+final class BackendUserGroupAccessCheck
+{
+    public function groupAccessGranted(array $record, Context $context): bool
+    {
+        if ($record['doktype'] !== 701) {
+            // Only check for manual pages
+            return true;
+        }
+
+        if (!$record['tx_ximatypo3manual_begroup']) {
+            // Anonymous access if no begroup restriction is set
+            return true;
+        }
+
+        // No backend user, but 'tx_ximatypo3manual_begroup' is not empty, so shut this down.
+        if (!$context->hasAspect('backend.user')) {
+            return false;
+        }
+
+        // Access for admins allowed
+        if ($context->getPropertyFromAspect('backend.user', 'isAdmin')) {
+            return true;
+        }
+
+        $pageGroupList = explode(',', (string)$record['tx_ximatypo3manual_begroup']);
+        return count(array_intersect($context->getAspect('backend.user')->getGroupIds(), $pageGroupList)) > 0;
+    }
+}
+

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -15,3 +15,13 @@ services:
     tags:
       - name: event.listener
         identifier: 'xima-typo3-manual/event-listener/modify-button-bar'
+
+  Xima\XimaTypo3Manual\EventListener\BackendUserGroupAccessEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'backendUserGroupAccessEventListener'
+
+  Xima\XimaTypo3Manual\DataProcessing\MenuAccessProcessor:
+    tags:
+      - name: 'data.processor'
+        identifier: 'menu-access-processor'

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -21,6 +21,22 @@ ExtensionManagementUtility::addTcaSelectItem(
     'after'
 );
 
+ExtensionManagementUtility::addTCAcolumns(
+    'pages',
+    [
+        'tx_ximatypo3manual_begroup' => [
+            'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang_db.xlf:pages.tx_ximatypo3manual_begroup',
+            'config' => [
+                'foreign_table' => 'be_groups',
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'size' => 7,
+                'maxitems' => 20,
+            ],
+        ],
+    ]
+);
+
 ArrayUtility::mergeRecursiveWithOverrule(
     $GLOBALS['TCA']['pages'],
     [
@@ -42,8 +58,15 @@ ArrayUtility::mergeRecursiveWithOverrule(
                         --palette--;;media,
                         --palette--;;config,is_siteroot,
                     --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access,
-                        --palette--;;visibility,',
+                        --palette--;;visibility,
+                        --palette--;;access_be,',
             ],
         ],
+        'palettes' => [
+            'access_be' => [
+                'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang_db.xlf:pages.palettes.access',
+                'showitem' => 'tx_ximatypo3manual_begroup',
+            ]
+        ]
     ]
 );

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2023-01-16T09:23:21Z">
+		<body>
+			<trans-unit id="pages.tx_ximatypo3manual_begroup">
+				<source />
+				<target>Zugriffsrechte für Backend Benutzergruppen</target>
+			</trans-unit>
+			<trans-unit id="pages.palettes.access">
+				<source />
+				<target>Zugriffsrechte</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="messages" date="2023-01-16T09:23:21Z">
+		<body>
+			<trans-unit id="pages.tx_ximatypo3manual_begroup">
+				<source>Access rights for backend user groups</source>
+			</trans-unit>
+			<trans-unit id="pages.palettes.access">
+				<source>Access rights</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,4 @@
+create table pages
+(
+	tx_ximatypo3manual_begroup varchar(255) DEFAULT '',
+);


### PR DESCRIPTION
In our project we need to distinguish between different user groups within the _multiple_ manuals, so I started a feature to configure the access restriction by choosing available backend user groups. 

For the root page it was quite easy with the RecordAccessGrantedEvent, but I struggle with the solution regarding the data processor to retrieve all pages / chapters. 

What do you think? 