### PR TITLE
Integrate manual chapters with records

### DIFF
--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -4,9 +4,12 @@ namespace Xima\XimaTypo3Manual\EventListener;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Template\Components\Buttons\DropDown\DropDownItem;
 use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final readonly class ModifyButtonBarEventListener
 {
@@ -20,23 +23,97 @@ final readonly class ModifyButtonBarEventListener
         $request = $GLOBALS['TYPO3_REQUEST'];
         $pageId = (int)($request->getParsedBody()['id'] ?? $request->getQueryParams()['id'] ?? 0);
 
-        if (!$pageId) {
+        $uri = $request->getUri()->getPath();
+        if (str_contains($uri, 'help/manual') || (!$pageId && !str_contains($uri, 'record/edit'))) {
             return;
         }
 
-        $uri = $request->getUri();
-        if (str_contains($uri, 'help/manual')) {
-            return;
+        $manualPages = [];
+
+        // edit record view
+        if (str_contains($uri, 'record/edit')) {
+            $editParam = $request->getQueryParams()['edit'] ?? '';
+            $recordTable = array_key_first($editParam);
+            $recordUid = (int)array_key_first($editParam[$recordTable] ?? []);
+            $recordType = $GLOBALS['TCA'][$recordTable]['ctrl']['type'] ?? '0';
+            array_push($manualPages, ...$this->getManualElementsForRecord($recordUid, $recordTable, $recordType));
+            array_push($manualPages, ...$this->getManualPagesForRecord($recordUid, $recordTable, $recordType));
         }
 
-        $manualButton = $event->getButtonBar()->makeLinkButton();
-        $manualButton->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => $pageId]));
-        $manualButton->setTitle('Manual');
-        $manualButton->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
+        // page view, list view, etc.
+        if ($pageId) {
+            array_push($manualPages, ...$this->getManualPagesForRecord($pageId, 'pages', 'doktype'));
+        }
+
         $buttons = $event->getButtons();
         $buttons['right'] ??= [];
-        $buttons['right'][] = [$manualButton];
+
+        if (count($manualPages)) {
+            $dropdown = $event->getButtonBar()->makeDropDownButton();
+            $dropdown->setLabel('Manual');
+            $dropdown->setTitle('Open manual page');
+            $dropdown->setShowLabelText(true);
+            $dropdown->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
+            foreach ($manualPages as $manualPage) {
+                // manual page
+                if (isset($manualPage['title'])) {
+                    $dropdown->addItem(
+                        GeneralUtility::makeInstance(DropDownItem::class)
+                            ->setLabel($manualPage['title'])
+                            ->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual',
+                                ['id' => $manualPage['uid']]))
+                    );
+                }
+                // manual element
+                if (isset($manualPage['header'])) {
+                    $dropdown->addItem(
+                        GeneralUtility::makeInstance(DropDownItem::class)
+                            ->setLabel($manualPage['header'])
+                            ->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual',
+                                ['id' => $manualPage['pid']]))
+                    );
+                }
+            }
+            $buttons['right'][] = [$dropdown];
+        } else {
+            $manualButton = $event->getButtonBar()->makeLinkButton();
+            $manualButton->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => $pageId]));
+            $manualButton->setTitle('Manual');
+            $manualButton->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
+
+            $buttons['right'][] = [$manualButton];
+        }
 
         $event->setButtons($buttons);
+    }
+
+    protected function getManualElementsForRecord(int $recordUid, string $recordTable, string $recordType): array
+    {
+        $sql = sprintf('select c.uid, c.pid, c.header from %s r, tt_content c where r.uid=%s and FIND_IN_SET(concat("%s:", r.%s), (c.tx_ximatypo3manual_relations)) and c.deleted=0 and c.hidden=0',
+            $recordTable, $recordUid, $recordTable, $recordType);
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
+        $result = $connection->executeQuery($sql)->fetchAllAssociative();
+
+        if (!$result) {
+            return [];
+        }
+
+        return $result;
+    }
+
+    protected function getManualPagesForRecord(int $recordUid, string $recordTable, string $recordType): array
+    {
+        $sql = sprintf('select p.uid, p.title from %s r, pages p where r.uid=%s and FIND_IN_SET(concat("%s:", r.%s), (p.tx_ximatypo3manual_relations)) and p.deleted=0 and p.hidden=0',
+            $recordTable, $recordUid, $recordTable, $recordType);
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
+        $result = $connection->executeQuery($sql)->fetchAllAssociative();
+
+        if (!$result) {
+            return [];
+        }
+
+        return $result;
     }
 }

--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -50,7 +50,7 @@ final readonly class ModifyButtonBarEventListener
 
         if (count($manualPages)) {
             $dropdown = $event->getButtonBar()->makeDropDownButton();
-            $dropdown->setLabel('Manual');
+            $dropdown->setLabel($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown'));
             $dropdown->setTitle('Open manual page');
             $dropdown->setShowLabelText(true);
             $dropdown->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
@@ -78,7 +78,7 @@ final readonly class ModifyButtonBarEventListener
         } else {
             $manualButton = $event->getButtonBar()->makeLinkButton();
             $manualButton->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => $pageId]));
-            $manualButton->setTitle('Manual');
+            $manualButton->setTitle($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown'));
             $manualButton->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
 
             $buttons['right'][] = [$manualButton];

--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -154,7 +154,8 @@ final readonly class ModifyButtonBarEventListener
     ): \TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton {
         $manualButton = $event->getButtonBar()->makeLinkButton();
         $manualButton->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => $pageId]));
-        $manualButton->setTitle($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown'));
+        $manualButton->setTitle($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown.all.title'));
+        $manualButton->setShowLabelText(true);
         $manualButton->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
         return $manualButton;
     }

--- a/Classes/UserFunctions/SelectItemsProcFunc.php
+++ b/Classes/UserFunctions/SelectItemsProcFunc.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Xima\XimaTypo3Manual\UserFunctions;
+
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+class SelectItemsProcFunc
+{
+    public static function getLabelForTableAndType(string $table, string|int $type): string
+    {
+        $fallbackLabel = $GLOBALS['TCA'][$table]['ctrl']['title'];
+
+        $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? null;
+        if (!$typeField) {
+            return $fallbackLabel;
+        }
+
+        $typeItems = $GLOBALS['TCA'][$table]['columns'][$typeField]['config']['items'] ?? [];
+        if (empty($typeItems)) {
+            return $fallbackLabel;
+        }
+
+        $index = array_search($type, array_column($typeItems, 'value'), false);
+        if ($index) {
+            $index = MathUtility::canBeInterpretedAsInteger($index) ? (int)$index : $index;
+            return $typeItems[$index]['label'] ?? $fallbackLabel;
+        }
+
+        return $fallbackLabel;
+    }
+
+    public static function getIconForTableAndType(string $table, string|int $type): string
+    {
+        $iconName = $type === 0 ? 'default' : $type;
+        if (isset($GLOBALS['TCA'][$table]['ctrl']['typeicon_classes'][$iconName])) {
+            return $GLOBALS['TCA'][$table]['ctrl']['typeicon_classes'][$iconName];
+        }
+
+        return $GLOBALS['TCA'][$table]['ctrl']['iconfile'] ?? '';
+    }
+
+    public function getItems(&$params): void
+    {
+        $items = [];
+
+        $tablesToSkip = [
+            'sys_category',
+            'be_groups',
+            'be_users',
+            'fe_groups',
+            'fe_users',
+            'sys_news',
+            'backend_layout',
+            'be_dashboards',
+            'tx_impexp_presets',
+            'sys_webhook',
+            'tx_extensionmanager_domain_model_extension',
+            'sys_file',
+            'sys_file_metadata',
+            'sys_file_reference',
+            'sys_file_storage',
+            'sys_filemounts',
+            'sys_language',
+            'sys_reaction',
+            'sys_language_overlay',
+            'sys_log',
+            'sys_note',
+            'sys_refindex',
+            'sys_template',
+            'sys_workspace',
+            'sys_file_collection',
+        ];
+
+        $tables = array_keys($GLOBALS['TCA']);
+        foreach ($tables as $table) {
+            if (in_array($table, $tablesToSkip, true)) {
+                continue;
+            }
+            foreach ($GLOBALS['TCA'][$table]['types'] as $type => $typeConfig) {
+                $label = self::getLabelForTableAndType($table, $type);
+                $typeCount = count($GLOBALS['TCA'][$table]['types']);
+
+                $item = [
+                    'value' => $table . ':' . $type,
+                    'label' => $GLOBALS['LANG']->sL($label),
+                    'icon' => self::getIconForTableAndType($table, $type),
+                ];
+
+                if ($typeCount > 1) {
+                    $item['group'] = $GLOBALS['LANG']->sL($GLOBALS['TCA'][$table]['ctrl']['title']);
+                } else {
+                    $item['group'] = 'Other';
+                }
+
+                $items[] = $item;
+            }
+        }
+        $params['items'] = $items;
+    }
+}

--- a/Classes/UserFunctions/SelectItemsProcFunc.php
+++ b/Classes/UserFunctions/SelectItemsProcFunc.php
@@ -9,7 +9,6 @@ class SelectItemsProcFunc
     public function getItems(&$params): void
     {
         $items = [];
-
         $tablesToSkip = [
             'sys_category',
             'be_groups',
@@ -57,7 +56,7 @@ class SelectItemsProcFunc
                 if ($typeCount > 1) {
                     $item['group'] = $GLOBALS['LANG']->sL($GLOBALS['TCA'][$table]['ctrl']['title']);
                 } else {
-                    $item['group'] = 'Other';
+                    $item['group'] = $GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:tx_ximatypo3manual_relation.other');
                 }
 
                 $items[] = $item;

--- a/Classes/UserFunctions/SelectItemsProcFunc.php
+++ b/Classes/UserFunctions/SelectItemsProcFunc.php
@@ -6,39 +6,6 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 class SelectItemsProcFunc
 {
-    public static function getLabelForTableAndType(string $table, string|int $type): string
-    {
-        $fallbackLabel = $GLOBALS['TCA'][$table]['ctrl']['title'];
-
-        $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? null;
-        if (!$typeField) {
-            return $fallbackLabel;
-        }
-
-        $typeItems = $GLOBALS['TCA'][$table]['columns'][$typeField]['config']['items'] ?? [];
-        if (empty($typeItems)) {
-            return $fallbackLabel;
-        }
-
-        $index = array_search($type, array_column($typeItems, 'value'), false);
-        if ($index) {
-            $index = MathUtility::canBeInterpretedAsInteger($index) ? (int)$index : $index;
-            return $typeItems[$index]['label'] ?? $fallbackLabel;
-        }
-
-        return $fallbackLabel;
-    }
-
-    public static function getIconForTableAndType(string $table, string|int $type): string
-    {
-        $iconName = $type === 0 ? 'default' : $type;
-        if (isset($GLOBALS['TCA'][$table]['ctrl']['typeicon_classes'][$iconName])) {
-            return $GLOBALS['TCA'][$table]['ctrl']['typeicon_classes'][$iconName];
-        }
-
-        return $GLOBALS['TCA'][$table]['ctrl']['iconfile'] ?? '';
-    }
-
     public function getItems(&$params): void
     {
         $items = [];
@@ -78,12 +45,13 @@ class SelectItemsProcFunc
             }
             foreach ($GLOBALS['TCA'][$table]['types'] as $type => $typeConfig) {
                 $label = self::getLabelForTableAndType($table, $type);
+                $icon = self::getIconForTableAndType($table, $type);
                 $typeCount = count($GLOBALS['TCA'][$table]['types']);
 
                 $item = [
                     'value' => $table . ':' . $type,
                     'label' => $GLOBALS['LANG']->sL($label),
-                    'icon' => self::getIconForTableAndType($table, $type),
+                    'icon' => $icon,
                 ];
 
                 if ($typeCount > 1) {
@@ -96,5 +64,38 @@ class SelectItemsProcFunc
             }
         }
         $params['items'] = $items;
+    }
+
+    public static function getLabelForTableAndType(string $table, string|int $type): string
+    {
+        $fallbackLabel = $GLOBALS['TCA'][$table]['ctrl']['title'];
+
+        $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? null;
+        if (!$typeField) {
+            return $fallbackLabel;
+        }
+
+        $typeItems = $GLOBALS['TCA'][$table]['columns'][$typeField]['config']['items'] ?? [];
+        if (empty($typeItems)) {
+            return $fallbackLabel;
+        }
+
+        $index = array_search($type, array_column($typeItems, 'value'), false);
+        if ($index) {
+            $index = MathUtility::canBeInterpretedAsInteger($index) ? (int)$index : $index;
+            return $typeItems[$index]['label'] ?? $fallbackLabel;
+        }
+
+        return $fallbackLabel;
+    }
+
+    public static function getIconForTableAndType(string $table, string|int $type): string
+    {
+        $iconName = $type === 0 ? 'default' : $type;
+        if (isset($GLOBALS['TCA'][$table]['ctrl']['typeicon_classes'][$iconName])) {
+            return $GLOBALS['TCA'][$table]['ctrl']['typeicon_classes'][$iconName];
+        }
+
+        return $GLOBALS['TCA'][$table]['ctrl']['iconfile'] ?? '';
     }
 }

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -6,7 +6,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 ExtensionManagementUtility::registerPageTSConfigFile(
     'xima_typo3_manual',
     'Configuration/TSconfig/Page.tsconfig',
-    'Xima Manual'
+    'XIMA Manual'
 );
 
 ExtensionManagementUtility::addTcaSelectItem(

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -61,7 +61,7 @@ ArrayUtility::mergeRecursiveWithOverrule(
                     --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                         --palette--;;standard,
                         --palette--;;title,
-                    --div--;LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:manual_relations,
+                    --div--;LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:tab.manual_relations,
                         --palette--;;manual-relations,
                     --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.resources,
                         --palette--;;media,

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -21,6 +21,29 @@ ExtensionManagementUtility::addTcaSelectItem(
     'after'
 );
 
+$tempFields = [
+    'tx_ximatypo3manual_relations' => [
+        'exclude' => true,
+        'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:tx_ximatypo3manual_relation',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectCheckBox',
+            'items' => [],
+            'appearance' => [
+                'expandAll' => true,
+            ],
+            'itemsProcFunc' => \Xima\XimaTypo3Manual\UserFunctions\SelectItemsProcFunc::class . '->getItems'
+        ],
+    ],
+];
+
+$GLOBALS['TCA']['pages']['palettes']['manual-relations'] = [
+    'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:palettes.manual_relations',
+    'showitem' => 'tx_ximatypo3manual_relations',
+];
+
+ExtensionManagementUtility::addTCAcolumns('pages', $tempFields);
+
 ArrayUtility::mergeRecursiveWithOverrule(
     $GLOBALS['TCA']['pages'],
     [
@@ -38,6 +61,8 @@ ArrayUtility::mergeRecursiveWithOverrule(
                     --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                         --palette--;;standard,
                         --palette--;;title,
+                    --div--;LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:manual_relations,
+                        --palette--;;manual-relations,
                     --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.resources,
                         --palette--;;media,
                         --palette--;;config,is_siteroot,

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -5,5 +5,5 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 ExtensionManagementUtility::addStaticFile(
     'xima_typo3_manual',
     'Configuration/TypoScript',
-    'Xima Manual'
+    'XIMA Manual'
 );

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,26 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+$tempFields = [
+    'tx_ximatypo3manual_relations' => [
+        'exclude' => true,
+        'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:tx_ximatypo3manual_relation',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectCheckBox',
+            'items' => [],
+            'appearance' => [
+                'expandAll' => true,
+            ],
+            'itemsProcFunc' => \Xima\XimaTypo3Manual\UserFunctions\SelectItemsProcFunc::class . '->getItems',
+        ],
+    ],
+];
+
+$GLOBALS['TCA']['tt_content']['palettes']['manual-relations'] = [
+    'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:palettes.manual_relations',
+    'showitem' => 'tx_ximatypo3manual_relations',
+];
+
+ExtensionManagementUtility::addTCAcolumns('tt_content', $tempFields);

--- a/Configuration/TCA/Overrides/tt_content_mtext.php
+++ b/Configuration/TCA/Overrides/tt_content_mtext.php
@@ -24,6 +24,8 @@ $GLOBALS['TCA']['tt_content']['palettes']['mtext'] = [
 $GLOBALS['TCA']['tt_content']['types']['mtext'] = [
     'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;mtext,
+                --div--;LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:manual_relations,
+                    --palette--;;manual-relations,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
                     --palette--;;language,colPos',
     'columnsOverrides' => [

--- a/Configuration/TCA/Overrides/tt_content_mtext.php
+++ b/Configuration/TCA/Overrides/tt_content_mtext.php
@@ -24,7 +24,7 @@ $GLOBALS['TCA']['tt_content']['palettes']['mtext'] = [
 $GLOBALS['TCA']['tt_content']['types']['mtext'] = [
     'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;mtext,
-                --div--;LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:manual_relations,
+                --div--;LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:tab.manual_relations,
                     --palette--;;manual-relations,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
                     --palette--;;language,colPos',

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # XIMA TYPO3 Manual Extension
 
-This extension provides a new page type for creating an editor manual right in the TYPO3 backend.
+This extension introduces a dedicated page type within TYPO3 backend, specifically designed for the creation of editor manuals. Administrators can easily craft user guides directly in the backend.
 
 ![Backend Preview](./Documentation/Images/backend_preview.png)
 
 ## Features
 
 * Backend module with preview
+* Seamless integration: Associate individual chapters to TYPO3 records for easy access
 * PDF download
-* Configured [bw_focuspoint_images](https://extensions.typo3.org/extension/bw_focuspoint_images) to annotate screenshots
-* Configured [bw_icons](https://extensions.typo3.org/extension/bw_icons) to add inline icons
+* Annotate screenshots with image editor: See [bw_focuspoint_images](https://extensions.typo3.org/extension/bw_focuspoint_images)
+* TYPO3 system icons available in RTE: See [bw_icons](https://extensions.typo3.org/extension/bw_icons)
 
 ## Installation
 
@@ -20,26 +21,8 @@ This extension provides a new page type for creating an editor manual right in t
    ```
 
 2. Create a new page in the page tree
-   * Select doctype "Manual page"
-   * Check "Use as Root Page"
-   * Include static PageTS
+   * Select Type "**Manual page**"
+   * Check "**Use as Root Page**"
+   * Include **static PageTS** "XIMA Manual"
 
-3. Create new Root-TypoScript template for this page + include static TypoScript of this extension
-
-## Transferring the manual
-
-An initial transfer can be done with the TYPO3 integrated [ImpExp extension](https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/). However, updating an existing page tree is not recommend - better wait for the upcoming extension [xima-typo3-page-sync](https://github.com/xima-media/xima-typo3-page-sync).
-
-### Export
-
-To export the pagetree of the manual, you could use the following command:
-
-```
-typo3cms impexp:export --type t3d_compressed --levels 999 --table _ALL --include-related --include-static sys_file_storage _ALL --pid <UID>
-```
-
-### Import
-
-```
-typo3cms impexp:import --update-records  fileadmin/user_upload/_temp_/importexport/<FILENAME>.t3d
-```
+3. Create new **Root-TypoScript** template for this page + include static TypoScript of this extension

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -50,6 +50,26 @@
 				<source />
 				<target>Textelement mit Überschrift und Fließtext</target>
 			</trans-unit>
+			<trans-unit id="tab.manual_relations">
+				<source />
+				<target>Verlinkte Elemente</target>
+			</trans-unit>
+			<trans-unit id="palettes.manual_relations">
+				<source />
+				<target>Verlinkungen erstellen</target>
+			</trans-unit>
+			<trans-unit id="tx_ximatypo3manual_relation">
+				<source />
+				<target>Verfügbare Elemente</target>
+			</trans-unit>
+			<trans-unit id="tx_ximatypo3manual_relation.other">
+				<source />
+				<target>Sonstige</target>
+			</trans-unit>
+			<trans-unit id="button.dropdown">
+				<source />
+				<target>Handbuch</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -70,6 +70,18 @@
 				<source />
 				<target>Handbuch</target>
 			</trans-unit>
+			<trans-unit id="button.dropdown.all.title">
+				<source />
+				<target>Handbuch öffnen</target>
+			</trans-unit>
+			<trans-unit id="button.dropdown.all">
+				<source />
+				<target>Handbuch öffnen</target>
+			</trans-unit>
+			<trans-unit id="button.dropdown.header">
+				<source />
+				<target>Zugehörige Kapitel</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -38,20 +38,20 @@
 			<trans-unit id="wizard.mtext.description">
 				<source>Text element with heading and body text</source>
 			</trans-unit>
-			<trans-unit id="manual_relations">
-				<source>Links</source>
+			<trans-unit id="tab.manual_relations">
+				<source>Related records</source>
 			</trans-unit>
 			<trans-unit id="palettes.manual_relations">
-				<source>Relations</source>
+				<source>Linking elements</source>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3manual_relation">
-				<source>Relation</source>
+				<source>Relations</source>
 			</trans-unit>
-			<trans-unit id="tx_ximatypo3manual_relation.table">
-				<source>Table</source>
+			<trans-unit id="tx_ximatypo3manual_relation.other">
+				<source>Other</source>
 			</trans-unit>
-			<trans-unit id="tx_ximatypo3manual_relation.table.default">
-				<source>All</source>
+			<trans-unit id="button.dropdown">
+				<source>Editor manual</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -38,6 +38,21 @@
 			<trans-unit id="wizard.mtext.description">
 				<source>Text element with heading and body text</source>
 			</trans-unit>
+			<trans-unit id="manual_relations">
+				<source>Links</source>
+			</trans-unit>
+			<trans-unit id="palettes.manual_relations">
+				<source>Relations</source>
+			</trans-unit>
+			<trans-unit id="tx_ximatypo3manual_relation">
+				<source>Relation</source>
+			</trans-unit>
+			<trans-unit id="tx_ximatypo3manual_relation.table">
+				<source>Table</source>
+			</trans-unit>
+			<trans-unit id="tx_ximatypo3manual_relation.table.default">
+				<source>All</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -53,6 +53,15 @@
 			<trans-unit id="button.dropdown">
 				<source>Editor manual</source>
 			</trans-unit>
+			<trans-unit id="button.dropdown.all.title">
+				<source>Open manual</source>
+			</trans-unit>
+			<trans-unit id="button.dropdown.all">
+				<source>Open manual</source>
+			</trans-unit>
+			<trans-unit id="button.dropdown.header">
+				<source>Associated chapters</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,7 @@
+create table pages (
+	tx_ximatypo3manual_relations text,
+);
+
+create table tt_content (
+	tx_ximatypo3manual_relations text,
+);


### PR DESCRIPTION
This pull request enables linking manual chapters directly to TYPO3 records like pages and content elements. Users now see direct links to associated manual chapters when viewing or editing records, enhancing usability.

resolves #2 