### PR TITLE
fix: display icons in mtext preview

### DIFF
--- a/Resources/Private/Backend/MtextPreview.html
+++ b/Resources/Private/Backend/MtextPreview.html
@@ -1,21 +1,11 @@
 {namespace be=TYPO3\CMS\Backend\ViewHelpers}
-<be:link.editRecord uid="{data.uid}" table="tt_content">
-    <f:format.raw>{data.bodytext->f:format.stripTags(allowedTags: '<p><span><strong><u><i><b>')}</f:format.raw>
-    <div>
-    <f:for each="{files}" as="file">
-        <f:image maxWidth="100" maxHeight="100" image="{file}"/>
-    </f:for>
-    </div>
-</be:link.editRecord>
-
-<style>
-    .t3-page-ce .t3-page-ce-body a:hover {
-        text-decoration: none;
-    }
-    .t3-page-ce .t3-page-ce-body img[data-icon-name] {
-        max-height: 16px;
-        margin-right: 2px;
-        position: relative;
-        top: -2px;
-    }
-</style>
+<div class="element-preview-mtext">
+    <be:link.editRecord uid="{data.uid}" table="tt_content">
+        <f:format.raw>{data.bodytext->f:format.stripTags(allowedTags: '<p><span><strong><u><i><b><img>')}</f:format.raw>
+        <div>
+            <f:for each="{files}" as="file">
+                <f:image maxWidth="100" maxHeight="100" image="{file}"/>
+            </f:for>
+        </div>
+    </be:link.editRecord>
+</div>

--- a/Resources/Public/Css/Backend/Manual.css
+++ b/Resources/Public/Css/Backend/Manual.css
@@ -11,3 +11,13 @@
 .typo3-module-xima_typo3_manual .module-body iframe {
     height: 100%;
 }
+.element-preview-mtext a:hover {
+    text-decoration: none;
+}
+
+.element-preview-mtext img[data-icon-name] {
+    max-height: 16px;
+    margin-right: 2px;
+    position: relative;
+    top: -2px;
+}


### PR DESCRIPTION
* Allow `<img>` tag in rendered `bodytext` preview
* Remove inline CSS