### PR TITLE
feat: open manual in modal when using doc header buttons

### DIFF
--- a/Classes/Controller/ManualController.php
+++ b/Classes/Controller/ManualController.php
@@ -55,15 +55,21 @@ class ManualController extends ActionController
             $this->getLanguageService()->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:mlang_tabs_tab')
         );
 
+        $context = $this->request->getQueryParams()['context'] ?? 'backend';
         $languageId = $this->getCurrentLanguage(
             $pageId,
             $this->request->getParsedBody()['language'] ?? $this->request->getQueryParams()['language'] ?? null
         );
-        $targetUrl = (string)PreviewUriBuilder::create($pageId)->withSection('p' . $pageId)->withAdditionalQueryParameters(['context' => 'backend'])->withLanguage($languageId)->buildUri();
+        $targetUrl = (string)PreviewUriBuilder::create($pageId)->withSection('p' . $pageId)->withAdditionalQueryParameters(['context' => $context])->withLanguage($languageId)->buildUri();
         $this->registerDocHeader($pageId, $languageId);
+
+        if ($context === 'iframe') {
+            $this->moduleTemplate->getDocHeaderComponent()->disable();
+        }
 
         $this->moduleTemplate->assign('url', $targetUrl);
         $this->moduleTemplate->assign('pid', $pageId);
+        $this->moduleTemplate->assign('context', $context);
 
         return $this->moduleTemplate->renderResponse();
     }

--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class ModifyButtonBarEventListener
@@ -32,6 +33,10 @@ final class ModifyButtonBarEventListener
         if (str_contains($uri, 'help/manual') || (!$pageId && !str_contains($uri, 'record/edit'))) {
             return;
         }
+
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer->loadJavaScriptModule('@xima/xima-typo3-manual/ManualModal.js');
 
         // extract manual pages that fit current view
         $manualPages = $this->getManualPages($uri, $request, $pageId);
@@ -134,9 +139,10 @@ final class ModifyButtonBarEventListener
             $dropdownItem = GeneralUtility::makeInstance(DropDownItem::class)
                 ->setIcon($this->iconFactory->getIcon('actions-dot', Icon::SIZE_SMALL))
                 ->setLabel($title)
+                ->setAttributes(['data-manual-modal' => 'open'])
                 ->setHref($this->uriBuilder->buildUriFromRoute(
                     'xima_typo3_manual',
-                    ['id' => $pid]
+                    ['id' => $pid, 'context' => 'iframe']
                 ));
             $dropdown->addItem($dropdownItem);
         }
@@ -147,9 +153,10 @@ final class ModifyButtonBarEventListener
         // generic manual link
         /** @var DropDownItemInterface $dropdownItem */
         $dropdownItem = GeneralUtility::makeInstance(DropDownItem::class)
-            ->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual'))
+            ->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => 0, 'context' => 'iframe']))
             ->setTitle($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown.all.title'))
             ->setLabel($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown.all'))
+            ->setAttributes(['data-manual-modal' => 'open'])
             ->setIcon($this->iconFactory->getIcon('actions-notebook', Icon::SIZE_SMALL));
         $dropdown->addItem($dropdownItem);
 
@@ -161,10 +168,11 @@ final class ModifyButtonBarEventListener
         int $pageId
     ): \TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton {
         $manualButton = $event->getButtonBar()->makeLinkButton();
-        $manualButton->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => $pageId]));
+        $manualButton->setHref($this->uriBuilder->buildUriFromRoute('xima_typo3_manual', ['id' => $pageId, 'context' => 'iframe']));
         $manualButton->setTitle($GLOBALS['LANG']->sL('LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:button.dropdown.all.title'));
         $manualButton->setShowLabelText(true);
         $manualButton->setIcon($this->iconFactory->getIcon('apps-pagetree-manual-root', Icon::SIZE_SMALL));
+        $manualButton->setDataAttributes(['manual-modal' => 'open']);
         return $manualButton;
     }
 }

--- a/Resources/Private/Templates/Manual/Index.html
+++ b/Resources/Private/Templates/Manual/Index.html
@@ -5,11 +5,7 @@
             width="100%"
             height="500"
             id="tx_viewpage_iframe"
+            data-context="{context}"
             title="{f:translate(key: 'LLL:EXT:viewpage/Resources/Private/Language/locallang.xlf:iframe.title')}"></iframe>
-    <style>
-        #tx_viewpage_iframe {
-            height: calc(100vh - 67px);
-        }
-    </style>
 </f:section>
 </html>

--- a/Resources/Public/Css/Backend/Manual.css
+++ b/Resources/Public/Css/Backend/Manual.css
@@ -11,6 +11,15 @@
 .typo3-module-xima_typo3_manual .module-body iframe {
     height: 100%;
 }
+
+#tx_viewpage_iframe {
+    height: calc(100vh - 67px);
+}
+
+#tx_viewpage_iframe[data-context="iframe"] {
+    height: 100vh;
+}
+
 .element-preview-mtext a:hover {
     text-decoration: none;
 }

--- a/Resources/Public/JavaScript/ManualModal.js
+++ b/Resources/Public/JavaScript/ManualModal.js
@@ -1,0 +1,21 @@
+import Modal from "@typo3/backend/modal.js";
+
+class ManualModal {
+  constructor() {
+    document.querySelectorAll('a[data-manual-modal]').forEach(item => {
+      item.addEventListener('click', e => {
+        e.preventDefault()
+        const url = e.currentTarget.getAttribute('href')
+        Modal.advanced({
+          type: Modal.types.iframe,
+          title: 'Manual',
+          content: url,
+          size: Modal.sizes.large,
+          staticBackdrop: true
+        });
+      })
+    })
+  }
+}
+
+export default new ManualModal()


### PR DESCRIPTION
When navigating to the manual via doc header (dropdown)buttons, the backend module is now loaded as iframe inside a modal.

Introduce a new view context: `iframe`. When used via query parameter, the doc header component is disabled + custom CSS is applied.