### PR TITLE
feat: add possibility to register additional tables to skip for relations

### DIFF
--- a/Classes/UserFunctions/SelectItemsProcFunc.php
+++ b/Classes/UserFunctions/SelectItemsProcFunc.php
@@ -36,6 +36,9 @@ class SelectItemsProcFunc
             'sys_workspace',
             'sys_file_collection',
         ];
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['xima_typo3_manual']['relations']['additionalTablesToSkip'] ?? null)) {
+            $tablesToSkip = array_merge($tablesToSkip, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['xima_typo3_manual']['relations']['additionalTablesToSkip']);
+        }
 
         $tables = array_keys($GLOBALS['TCA']);
         foreach ($tables as $table) {


### PR DESCRIPTION
E.g. 
`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['xima_typo3_manual']['relations']['additionalTablesToSkip'] = ['tx_kesearch_filters'];`