### PR TITLE
fix: cover logo alignment

### DIFF
--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -263,7 +263,7 @@ nav a.active {
  */
 section.cover {
     display: grid;
-    justify-content: center;
+    justify-items: center;
     padding: calc(2 * var(--space)) 0;
     gap: calc(2 * var(--space));
 }


### PR DESCRIPTION
If the logo is smaller than the manual title, the image is not properly aligned 