### PR TITLE
fix: tca types index can be missing

### DIFF
--- a/Classes/UserFunctions/SelectItemsProcFunc.php
+++ b/Classes/UserFunctions/SelectItemsProcFunc.php
@@ -45,7 +45,7 @@ class SelectItemsProcFunc
             if (in_array($table, $tablesToSkip, true)) {
                 continue;
             }
-            foreach ($GLOBALS['TCA'][$table]['types'] as $type => $typeConfig) {
+            foreach ($GLOBALS['TCA'][$table]['types'] ?? [] as $type => $typeConfig) {
                 $label = self::getLabelForTableAndType($table, $type);
                 $icon = self::getIconForTableAndType($table, $type);
                 $typeCount = count($GLOBALS['TCA'][$table]['types']);


### PR DESCRIPTION
Having TCA tables in the installation that do not define `types`, this UserFunction raised an error.