### PR TITLE
fix: remove css inline width

### DIFF
--- a/Resources/Private/bw_focuspoint_images/Templates/FocuspointImage.html
+++ b/Resources/Private/bw_focuspoint_images/Templates/FocuspointImage.html
@@ -31,7 +31,7 @@
     </div>
 
     <f:if condition="{image}">
-        <div class="focuspoint" style="width:{image.properties.width}px">
+        <div class="focuspoint">
 
             <f:image image="{image}"/>
 


### PR DESCRIPTION
When using the focuspoint element inside a slider, the inline width causes the slide to break to break out of the container.