### PR TITLE
fix: add header field to mbox element

### DIFF
--- a/Configuration/TCA/Overrides/tt_content_mbox.php
+++ b/Configuration/TCA/Overrides/tt_content_mbox.php
@@ -18,7 +18,7 @@ $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['mbox'] = 'content-ide
 
 $GLOBALS['TCA']['tt_content']['palettes']['mbox'] = [
     'label' => 'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:mbox.palette',
-    'showitem' => 'layout,--linebreak--,bodytext',
+    'showitem' => 'header,--linebreak--,layout,--linebreak--,bodytext',
 ];
 
 $GLOBALS['TCA']['tt_content']['types']['mbox'] = [


### PR DESCRIPTION
When adding a translation or copy of a mbox element, the header becomes suffixed with "(copy x)" and cannot be removed. 