### PR TITLE
feat: hide not used fields in all tt_content elements

### DIFF
--- a/Configuration/TSconfig/Page.tsconfig
+++ b/Configuration/TSconfig/Page.tsconfig
@@ -53,11 +53,19 @@ mod.wizards.newContentElement.wizardItems {
   ext-news.show =
 }
 
-TCEFORM.tt_content.CType.keepItems = mtext,mbox,msteps,bw_focuspoint_images_svg
-TCEFORM.tt_content.assets.config.maxitems = 1
-TCEFORM.tt_content.imageorient.disabled = 0
-TCEFORM.tt_content.imageorient.removeItems = 1,2,9,10,17,18
-TCEFORM.tt_content.colPos.addItems.1 = Content Slider
+TCEFORM.tt_content {
+  CType.keepItems = mtext,mbox,msteps,bw_focuspoint_images_svg
+  assets.config.maxitems = 1
+  imageorient.disabled = 0
+  imageorient.removeItems = 1,2,9,10,17,18
+  colPos.addItems.1 = Content Slider
+  header_layout.disabled = 1
+  header_position.disabled = 1
+  date.disabled = 1
+  header_link.disabled = 1
+  subheader.disabled = 1
+  tx_bwicons_icon.disabled = 1
+}
 
 mod.tx_bwfocuspointimages.settings.fields {
 


### PR DESCRIPTION
The focuspoint element displays many header fields that are not needed