### PR TITLE
feat: max-width and lazy loading for focuspoint images

### DIFF
--- a/Resources/Private/bw_focuspoint_images/Templates/FocuspointImage.html
+++ b/Resources/Private/bw_focuspoint_images/Templates/FocuspointImage.html
@@ -33,7 +33,7 @@
     <f:if condition="{image}">
         <div class="focuspoint">
 
-            <f:image image="{image}"/>
+            <f:image maxWidth="1200" loading="lazy" image="{image}"/>
 
             <svg class="focuspoint__svg" xmlns="http://www.w3.org/2000/svg">
 


### PR DESCRIPTION
To improve the performance of the manual, add `maxWidth` and `loading="lazy"` to the focuspoint images.