### PR TITLE
Element wizard: Prevent global registration

### DIFF
--- a/Configuration/TCA/Overrides/tt_content_mannotation.php
+++ b/Configuration/TCA/Overrides/tt_content_mannotation.php
@@ -10,6 +10,8 @@ ExtensionManagementUtility::addTcaSelectItem(
         'LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.title',
         'mannotation',
         'bw_focuspoint_images_svg',
+        'default',
+        'LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.description',
     ],
     'image',
     'after'

--- a/Configuration/TCA/Overrides/tt_content_mbox.php
+++ b/Configuration/TCA/Overrides/tt_content_mbox.php
@@ -6,9 +6,11 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'Box',
+        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:wizard.mbox.title',
         'mbox',
         'content-idea',
+        'default',
+        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:wizard.mbox.description',
     ],
     'image',
     'after'

--- a/Configuration/TCA/Overrides/tt_content_msteps.php
+++ b/Configuration/TCA/Overrides/tt_content_msteps.php
@@ -6,9 +6,11 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:msteps',
+        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:wizard.msteps.title',
         'msteps',
         'content-carousel-item-textandimage',
+        'default',
+        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:wizard.msteps.description',
     ],
     'image',
     'after'

--- a/Configuration/TCA/Overrides/tt_content_mtext.php
+++ b/Configuration/TCA/Overrides/tt_content_mtext.php
@@ -6,9 +6,11 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'Standard',
+        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:wizard.mtext.title',
         'mtext',
         'content-beside-text-img-below-center',
+        'default',
+        'LLL:EXT:xima_typo3_manual/Resources/Private/Language/locallang.xlf:wizard.mtext.description'
     ],
     'image',
     'after'

--- a/Configuration/TSconfig/Page.tsconfig
+++ b/Configuration/TSconfig/Page.tsconfig
@@ -1,3 +1,9 @@
+# Remove the exclusion of the bw_focuspoint_images_svg content element from the new content element wizard
+mod.wizards.newContentElement.wizardItems {
+  default.removeItems := removeFromList(mannotation,mbox,msteps,mtext)
+}
+
+# Legacy content element registration for v12
 mod.wizards.newContentElement.wizardItems {
 
   xima_typo3_manual {

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,4 @@
+# Remove all content elements from wizard (should not be available globally)
+mod.wizards.newContentElement.wizardItems {
+  default.removeItems := addToList(mannotation,mbox,msteps,mtext)
+}


### PR DESCRIPTION
This PR removes the global element registration of the 4 content elements shipped with this extension.