### PR TITLE
fix: set explicit nullable parameter type to fix deprecation

### DIFF
--- a/Classes/Controller/ManualController.php
+++ b/Classes/Controller/ManualController.php
@@ -123,7 +123,7 @@ class ManualController extends ActionController
         return $GLOBALS['LANG'];
     }
 
-    protected function getCurrentLanguage(int $pageId, string $languageParam = null): int
+    protected function getCurrentLanguage(int $pageId, ?string $languageParam = null): int
     {
         $languageId = (int)$languageParam;
         if ($languageParam === null) {


### PR DESCRIPTION
fixes following deprecation:
Deprecated: Xima\XimaTypo3Manual\Controller\ManualController::getCurrentLanguage(): Implicitly marking parameter $languageParam as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/xima/xima-typo3-manual/Classes/Controller/ManualController.php on line 126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved method parameter handling to better support cases where no language is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->