### PR TITLE
feat: restrict doktypes to manual pages only

### DIFF
--- a/Configuration/TSconfig/Page.tsconfig
+++ b/Configuration/TSconfig/Page.tsconfig
@@ -74,6 +74,8 @@ TCEFORM.tt_content {
   layout >
 }
 
+TCEFORM.pages.doktype.keepItems = 701
+
 mod.tx_bwfocuspointimages.settings.fields {
 
   type {


### PR DESCRIPTION
Only doktype 701 should be available for new pages in page tree of manual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend system configuration to expand support for additional page type options, allowing greater flexibility in content structure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->