### PR TITLE
feat: add table support in RTE

### DIFF
--- a/Configuration/RTE/Manual.yaml
+++ b/Configuration/RTE/Manual.yaml
@@ -9,6 +9,15 @@ editor:
     externalPlugins:
         typo3link: { resource: "EXT:rte_ckeditor/Resources/Public/JavaScript/Plugins/typo3link.js", route: "rteckeditor_wizard_browse_links" }
     config:
+        contentsCss:
+            - "EXT:xima_typo3_manual/Resources/Public/Css/Frontend/rte-content.css"
+        table:
+            contentToolbar:
+                - tableColumn
+                - tableRow
+                - mergeTableCells
+                - tableProperties
+                - tableCellProperties
         toolbar:
             items:
               - { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline' ] }
@@ -17,6 +26,7 @@ editor:
               - { name: 'lists', items: [ 'NumberedList', 'BulletedList' ] }
               - { name: 'clipboard', items: [ 'Undo', 'Redo' ] }
               - { name: 'format', items: [ 'Paste', 'RemoveFormat', 'Link' ] }
+              - { name: 'table', items: [ 'Table' ] }
               - { name: 'icon', items: [ 'IconPicker' ] }
         style:
           definitions:

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -178,6 +178,10 @@ figcaption {
     grid-column: 1 / 2;
 }
 
+.ce-image .ce-bodytext {
+    min-width: 0;
+}
+
 .ce-focuspoint-bodytext {
     margin-bottom: var(--space);
 }
@@ -269,6 +273,39 @@ section.cover {
 }
 
 /** RTE styles */
+.ce-bodytext figure.table {
+    overflow-x: auto;
+    max-width: 100%;
+}
+
+.ce-bodytext table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: var(--space);
+}
+
+.ce-bodytext table thead,
+.ce-bodytext table tbody,
+.ce-bodytext table tfoot,
+.ce-bodytext table tr {
+    background-color: inherit;
+}
+
+.ce-bodytext table th,
+.ce-bodytext table td {
+    padding: .5rem calc(var(--space) * 0.75);
+    border: 1px solid #adadad;
+    text-align: left;
+    vertical-align: top;
+    background-color: inherit;
+}
+
+.ce-bodytext table thead th {
+    background-color: #e0e0e0;
+    font-weight: bold;
+}
+
+
 span.badge {
     background-color: #ececec;
     font-size: 75%;

--- a/Resources/Public/Css/Frontend/rte-content.css
+++ b/Resources/Public/Css/Frontend/rte-content.css
@@ -1,0 +1,32 @@
+figure.table {
+    overflow-x: auto;
+    max-width: 100%;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+}
+
+thead,
+tbody,
+tfoot,
+tr {
+    background-color: inherit;
+}
+
+th,
+td {
+    padding: .5rem .75rem;
+    border: 1px solid #adadad;
+    text-align: left;
+    vertical-align: top;
+    background-color: inherit;
+}
+
+thead th {
+    background-color: #e0e0e0;
+    font-weight: bold;
+}
+

--- a/Resources/Public/Css/Frontend/rte-content.css
+++ b/Resources/Public/Css/Frontend/rte-content.css
@@ -29,4 +29,3 @@ thead th {
     background-color: #e0e0e0;
     font-weight: bold;
 }
-


### PR DESCRIPTION
 Closes #84 

- Enables table insertion and editing in the CKEditor 5 RTE for the `mtext` content element
- Adds contextual table toolbar (column/row operations, merge cells, table/cell properties)
- Adds frontend CSS for consistent table rendering (borders, header styling, overflow handling)
- Adds `contentsCss` for WYSIWYG preview of table styles in the editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded rich text editor with complete table support, including configurable table toolbar controls for column/row operations, merge functions, and cell management. Added comprehensive table styling with proper borders, padding, alignment, and distinct header formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->