### PR TITLE
Improve navigation counter layout, heading typography, and editable logo/title

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -15,7 +15,7 @@ page {
       context.value = frontend
       context.override.data = GP:context
       title = TEXT
-      title.data = page:title
+      title.data = levelfield:0,title
     }
 
     dataProcessing {

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -15,8 +15,7 @@ page {
       context.value = frontend
       context.override.data = GP:context
       title = TEXT
-      title.data = site:websiteTitle
-      title.override.data = siteLanguage:websiteTitle
+      title.data = page:title
     }
 
     dataProcessing {
@@ -41,6 +40,14 @@ page {
 
       # Backend settings
       20 = Xima\XimaTypo3Manual\DataProcessing\BackendSettingsProcessor
+
+      # Manual logo from root page media field
+      40 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
+      40 {
+        references.fieldName = media
+        as = manualLogo
+        maxItems = 1
+      }
 
       # Language menu
       30 = TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -44,6 +44,8 @@ page {
       # Manual logo from root page media field
       40 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
       40 {
+        references.table = pages
+        references.uid.data = levelUid:0
         references.fieldName = media
         as = manualLogo
         maxItems = 1

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -15,7 +15,7 @@ page {
       context.value = frontend
       context.override.data = GP:context
       title = TEXT
-      title.data = levelfield:0,title
+      title.data = leveltitle:0
     }
 
     dataProcessing {

--- a/Resources/Private/Templates/Default.html
+++ b/Resources/Private/Templates/Default.html
@@ -46,11 +46,9 @@
             <f:then>
                 <f:image image="{manualLogo.0}" width="300" alt="Logo"/>
             </f:then>
-            <f:else>
-                <f:if condition="{backendSettings.loginLogo}">
-                    <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
-                </f:if>
-            </f:else>
+            <f:elseif condition="{backendSettings.loginLogo}">
+                <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
+            </f:elseif>
         </f:if>
         <h1>{title}</h1>
     </section>

--- a/Resources/Private/Templates/Default.html
+++ b/Resources/Private/Templates/Default.html
@@ -46,9 +46,9 @@
             <f:then>
                 <f:image image="{manualLogo.0}" width="300" alt="Logo"/>
             </f:then>
-            <f:elseif condition="{backendSettings.loginLogo}">
+            <f:else if="{backendSettings.loginLogo}">
                 <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
-            </f:elseif>
+            </f:else>
         </f:if>
         <h1>{title}</h1>
     </section>

--- a/Resources/Private/Templates/Default.html
+++ b/Resources/Private/Templates/Default.html
@@ -42,8 +42,15 @@
 <main>
 
     <section class="section cover">
-        <f:if condition="{backendSettings.loginLogo}">
-            <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
+        <f:if condition="{manualLogo.0}">
+            <f:then>
+                <f:image image="{manualLogo.0}" width="300" alt="Logo"/>
+            </f:then>
+            <f:else>
+                <f:if condition="{backendSettings.loginLogo}">
+                    <img src="{f:uri.resource(path: backendSettings.loginLogo)}" width="300" alt="Logo"/>
+                </f:if>
+            </f:else>
         </f:if>
         <h1>{title}</h1>
     </section>

--- a/Resources/Private/fluid_styled_content/Templates/Mannotation.html
+++ b/Resources/Private/fluid_styled_content/Templates/Mannotation.html
@@ -103,7 +103,7 @@
         </div>
 
         <f:for each="{points.{img-i.index}}" as="point" iteration="i">
-            <f:if condition="{point.description}">
+            <f:if condition="{point.title} || {point.description}">
                 <div class="focuspoint__description" id="focuspoint-{data.uid}-{i.cycle}">
                     <strong>{f:if(condition: '{point.type}==marking', then: '{i.cycle}. ')}{point.title}</strong>
                     <p>

--- a/Resources/Private/fluid_styled_content/Templates/Mannotation.html
+++ b/Resources/Private/fluid_styled_content/Templates/Mannotation.html
@@ -105,7 +105,9 @@
         <f:for each="{points.{img-i.index}}" as="point" iteration="i">
             <f:if condition="{point.title} || {point.description}">
                 <div class="focuspoint__description" id="focuspoint-{data.uid}-{i.cycle}">
-                    <strong>{f:if(condition: '{point.type}==marking', then: '{i.cycle}. ')}{point.title}</strong>
+                    <f:if condition="{point.title}">
+                        <strong>{f:if(condition: '{point.type}==marking', then: '{i.cycle}. ')}{point.title}</strong>
+                    </f:if>
                     <f:if condition="{point.description}">
                         <p>
                             <f:format.nl2br>{point.description}</f:format.nl2br>

--- a/Resources/Private/fluid_styled_content/Templates/Mannotation.html
+++ b/Resources/Private/fluid_styled_content/Templates/Mannotation.html
@@ -106,9 +106,11 @@
             <f:if condition="{point.title} || {point.description}">
                 <div class="focuspoint__description" id="focuspoint-{data.uid}-{i.cycle}">
                     <strong>{f:if(condition: '{point.type}==marking', then: '{i.cycle}. ')}{point.title}</strong>
-                    <p>
-                        <f:format.nl2br>{point.description}</f:format.nl2br>
-                    </p>
+                    <f:if condition="{point.description}">
+                        <p>
+                            <f:format.nl2br>{point.description}</f:format.nl2br>
+                        </p>
+                    </f:if>
                 </div>
             </f:if>
         </f:for>

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -108,6 +108,11 @@ main > section > section > section > h2:first-child, main > section > section > 
 
 main > section > section > section > section > h2:first-child, main > section > section > section > div > header > h3 {
     counter-increment: counter-level-4;
+    counter-reset: counter-level-5;
+}
+
+main > section > section > section > section > section > h2:first-child, main > section > section > section > section > div > header > h3 {
+    counter-increment: counter-level-5;
 }
 
 main > section > h2:before {
@@ -124,6 +129,10 @@ main > section > section > section > h2:before, main > section > section > div >
 
 main > section > section > section > section > h2:before, main > section > section > section > div > header > h3:before {
     content: counter(counter-level-1) "." counter(counter-level-2) "." counter(counter-level-3) "." counter(counter-level-4) " ";
+}
+
+main > section > section > section > section > section > h2:before, main > section > section > section > section > div > header > h3:before {
+    content: counter(counter-level-1) "." counter(counter-level-2) "." counter(counter-level-3) "." counter(counter-level-4) "." counter(counter-level-5) " ";
 }
 
 ol > li::marker {
@@ -243,11 +252,36 @@ nav li, nav summary {
 }
 
 nav ol {
+    padding-left: 1.5rem;
     margin-bottom: 0.4rem !important;
+    counter-reset: nav-counter;
+}
+
+nav li {
+    counter-increment: nav-counter;
+}
+
+nav li::marker {
+    content: '';
+}
+
+nav li:not(:has(> details)) {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.25rem;
+}
+
+nav li:not(:has(> details))::before {
+    content: counters(nav-counter, '.') ". ";
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 summary {
-    position: relative;
+    list-style: none;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.25rem;
 }
 
 summary::marker {
@@ -255,18 +289,15 @@ summary::marker {
 }
 
 summary:before {
-    content: "►";
-    float: left;
-    position: absolute;
-    left: -45px;
-}
-
-details details summary:before {
-    left: -55px;
+    content: "► " counters(nav-counter, '.') ". ";
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 details[open] > summary:before {
-    content: "▼";
+    content: "▼ " counters(nav-counter, '.') ". ";
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 nav a.active {

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -29,12 +29,23 @@ h1, h2, h3, h4, h5, h6 {
     font-family: 'Montserrat', 'Arial', 'Helvetica Neue', Helvetica, sans-serif
 }
 
+h1 {
+    font-size: 2.5rem;
+}
+
 h2 {
+    font-size: 1.75rem;
     margin-bottom: calc(1 * var(--space));
 }
 
 h3 {
+    font-size: 1.5rem;
     margin-bottom: calc(0.75 * var(--space));
+}
+
+h4 {
+    font-size: 1.25rem;
+    margin-bottom: calc(0.5 * var(--space));
 }
 
 h2 svg {

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -100,19 +100,19 @@ main > section > section > section > section > h2:first-child, main > section > 
 }
 
 main > section > h2:before {
-    content: counter(counter-level-1) ". ";
+    content: counter(counter-level-1) " ";
 }
 
 main > section > section > h2:before, main > section > div > header > h3:before {
-    content: counter(counter-level-1) "." counter(counter-level-2) ". ";
+    content: counter(counter-level-1) "." counter(counter-level-2) " ";
 }
 
 main > section > section > section > h2:before, main > section > section > div > header > h3:before {
-    content: counter(counter-level-1) "." counter(counter-level-2) "." counter(counter-level-3) ". ";
+    content: counter(counter-level-1) "." counter(counter-level-2) "." counter(counter-level-3) " ";
 }
 
 main > section > section > section > section > h2:before, main > section > section > section > div > header > h3:before {
-    content: counter(counter-level-1) "." counter(counter-level-2) "." counter(counter-level-3) "." counter(counter-level-4) ". ";
+    content: counter(counter-level-1) "." counter(counter-level-2) "." counter(counter-level-3) "." counter(counter-level-4) " ";
 }
 
 ol > li::marker {

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -289,15 +289,21 @@ summary::marker {
 }
 
 summary:before {
-    content: "► " counters(nav-counter, '.') " ";
+    content: counters(nav-counter, '.') " ";
     flex-shrink: 0;
     white-space: nowrap;
 }
 
-details[open] > summary:before {
-    content: "▼ " counters(nav-counter, '.') " ";
-    flex-shrink: 0;
-    white-space: nowrap;
+summary:after {
+    content: "►";
+    display: inline-block;
+    transition: transform 0.2s;
+    order: -1;
+    margin-right: 0.25rem;
+}
+
+details[open] > summary:after {
+    transform: rotate(90deg);
 }
 
 nav a.active {

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -272,7 +272,7 @@ nav li:not(:has(> details)) {
 }
 
 nav li:not(:has(> details))::before {
-    content: counters(nav-counter, '.') ". ";
+    content: counters(nav-counter, '.') " ";
     flex-shrink: 0;
     white-space: nowrap;
 }
@@ -289,13 +289,13 @@ summary::marker {
 }
 
 summary:before {
-    content: "► " counters(nav-counter, '.') ". ";
+    content: "► " counters(nav-counter, '.') " ";
     flex-shrink: 0;
     white-space: nowrap;
 }
 
 details[open] > summary:before {
-    content: "▼ " counters(nav-counter, '.') ". ";
+    content: "▼ " counters(nav-counter, '.') " ";
     flex-shrink: 0;
     white-space: nowrap;
 }


### PR DESCRIPTION
 Fixes #98  several visual and editorial issues in the frontend output.

  **Navigation**
  - Counter prefix uses flexbox to prevent wrapping at deep nesting levels

  **Headings**
  - Adjusted heading sizes: h1 2.5rem, h2 1.75rem, h3 1.5rem, h4 1.25rem
  - Removed trailing dot from numbered headings (3.8. → 3.8)

  **Editable logo and title**
  - Manual title now reads from the root page `title` field
  - Logo now reads from the root page `media` field via `FilesProcessor`, with fallback to the backend login logo

  **Annotation fixes**
  - Focus point markers with only a title (no description) are now rendered correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for manual/custom logos with automatic fallback to the default logo.

* **Style**
  * Updated heading typography with explicit font sizing and refined spacing.
  * Revamped sticky navigation numbering and visual expand/collapse indicators.

* **Bug Fixes**
  * Annotation rendering improved to show titles and descriptions independently when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->